### PR TITLE
Recover from a refused token refresh instead of crashing

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import importlib
+
 import pytest
 
 from veeam_br.client import VeeamClient, _camel_to_snake
@@ -123,3 +125,178 @@ def _far_future():
     from datetime import datetime, timedelta, timezone
 
     return datetime.now(timezone.utc) + timedelta(hours=1)
+
+
+# ---------------------------------------------------------------------------
+# Token handling when the server refuses the login
+#
+# create_token returns an Error model for a documented failure (401) and None for an
+# undocumented status; it does not raise. Treating either as a token used to surface as
+# "'Error' object has no attribute 'access_token'" from deep inside a refresh, and left
+# every later call using a dead token.
+# See https://github.com/Cenvora/ha-veeam-br/issues/82
+# ---------------------------------------------------------------------------
+
+
+class FakeError:
+    """Shaped like the generated Error model."""
+
+    def __init__(self, message="Unauthorized", error_code="unauthorized"):
+        self.message = message
+        self.error_code = error_code
+
+
+class FakeToken:
+    def __init__(self, access_token="access", refresh_token="refresh", expires_in=900):
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.expires_in = expires_in
+
+
+def _fake_authenticated_client(**kwargs):
+    return object()
+
+
+@pytest.mark.parametrize(
+    "result",
+    [FakeError(), None, object()],
+    ids=["error-model", "no-token", "unexpected-object"],
+)
+def test_store_token_rejects_non_tokens(result):
+    vc = make_client()
+
+    with pytest.raises(PermissionError, match="Veeam login failed"):
+        vc._store_token(result, _fake_authenticated_client)
+
+    assert vc._access_token is None, "a refused login must not look authenticated"
+    assert vc._expires_at is None
+
+
+def test_store_token_reports_the_server_message():
+    vc = make_client()
+
+    with pytest.raises(PermissionError, match="wrong credentials"):
+        vc._store_token(FakeError(message="wrong credentials"), _fake_authenticated_client)
+
+
+@pytest.mark.asyncio
+async def test_refresh_falls_back_to_password_when_refresh_is_refused(monkeypatch):
+    """A revoked refresh token comes back as an Error, not an exception."""
+    vc = make_client()
+    vc._client = object()
+    vc._access_token = "stale"
+    vc._refresh_token = "revoked"
+    vc._expires_at = None  # expired
+
+    connected = []
+
+    async def fake_connect():
+        connected.append(True)
+        vc._access_token = "fresh"
+
+    monkeypatch.setattr(vc, "connect", fake_connect)
+    monkeypatch.setattr(
+        "veeam_br.client.importlib.import_module",
+        _refusing_login_modules(),
+    )
+
+    await vc._refresh_token_if_needed()
+
+    assert connected, "a refused refresh should re-authenticate with the password grant"
+    assert vc._access_token == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_refresh_connects_when_there_is_no_refresh_token(monkeypatch):
+    vc = make_client()
+    connected = []
+
+    async def fake_connect():
+        connected.append(True)
+
+    monkeypatch.setattr(vc, "connect", fake_connect)
+
+    await vc._refresh_token_if_needed()
+
+    assert connected, "with no token to refresh, it should connect from scratch"
+
+
+@pytest.mark.asyncio
+async def test_call_invalidates_session_on_undecodable_response():
+    """An empty body from a rejected token must not poison every later call."""
+    from json import JSONDecodeError
+
+    vc = make_client()
+    vc._client = object()
+    vc._access_token = "stale"
+    vc._refresh_token = "stale-refresh"
+    vc._expires_at = _far_future()
+
+    async def fake_operation(**kwargs):
+        raise JSONDecodeError("Expecting value", "", 0)
+
+    with pytest.raises(PermissionError, match="undecodable response"):
+        await vc.call(fake_operation)
+
+    assert vc._access_token is None, "the dead session should be dropped"
+    assert vc._refresh_token is None
+    assert vc._expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_call_does_not_retry_the_operation():
+    """Retrying could repeat a non-idempotent operation such as starting a job."""
+    from json import JSONDecodeError
+
+    vc = make_client()
+    vc._client = object()
+    vc._expires_at = _far_future()
+
+    calls = []
+
+    async def fake_operation(**kwargs):
+        calls.append(True)
+        raise JSONDecodeError("Expecting value", "", 0)
+
+    with pytest.raises(PermissionError):
+        await vc.call(fake_operation)
+
+    assert len(calls) == 1, "the operation must be attempted exactly once"
+
+
+def _refusing_login_modules():
+    """Stand in for importlib.import_module so the refresh grant is refused."""
+    real_import = importlib.import_module
+
+    class FakeCreateToken:
+        @staticmethod
+        async def asyncio(**kwargs):
+            return FakeError()
+
+    class FakeSpec:
+        def __init__(self, **kwargs):
+            pass
+
+    class FakeGrantType:
+        REFRESH_TOKEN = "refresh_token"
+        PASSWORD = "password"
+
+    def fake_import(name):
+        if name.endswith(".api.login.create_token"):
+            return FakeCreateToken
+        if name.endswith(".models.token_login_spec"):
+            return type("M", (), {"TokenLoginSpec": FakeSpec})
+        if name.endswith(".models.e_login_grant_type"):
+            return type("M", (), {"ELoginGrantType": FakeGrantType})
+        if name.endswith(".client"):
+            return type(
+                "M",
+                (),
+                {
+                    "Client": lambda **kw: object(),
+                    "AuthenticatedClient": _fake_authenticated_client,
+                },
+            )
+        return real_import(name)
+
+    return fake_import

--- a/veeam_br/client.py
+++ b/veeam_br/client.py
@@ -1,6 +1,7 @@
 import importlib
 import re
 from datetime import datetime, timedelta, timezone
+from json import JSONDecodeError
 from typing import Any
 
 # ----------------------------
@@ -11,6 +12,31 @@ from typing import Any
 def _camel_to_snake(name: str) -> str:
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _is_token(candidate: Any) -> bool:
+    """Whether a create_token result is actually a token.
+
+    The login operation returns a TokenModel on success, but an Error model for a
+    documented failure such as 401, and None for an undocumented status. Reading
+    .access_token off those raises AttributeError far from the real cause.
+    """
+    fields = ("access_token", "refresh_token", "expires_in")
+    return all(hasattr(candidate, field) for field in fields)
+
+
+def _describe_login_failure(result: Any) -> str:
+    """Explain a create_token result that is not a token."""
+    if result is None:
+        return "the server returned no token and an unexpected status"
+
+    message = getattr(result, "message", None)
+    error_code = getattr(result, "error_code", None)
+    if message or error_code:
+        code = getattr(error_code, "value", error_code)
+        return f"the server rejected the login: {message or ''} ({code})".replace(" ()", "")
+
+    return f"the server returned {type(result).__name__} instead of a token"
 
 
 # ----------------------------
@@ -129,6 +155,13 @@ class VeeamClient:
     # ----------------------------
 
     def _store_token(self, token, AuthenticatedClient):
+        if not _is_token(token):
+            # Without this the next line raises AttributeError ("'Error' object has no
+            # attribute 'access_token'"), which says nothing about the credentials being
+            # refused. PermissionError lets a caller tell "wrong password" from
+            # "server unreachable" and prompt for re-authentication.
+            raise PermissionError(f"Veeam login failed: {_describe_login_failure(token)}")
+
         self._access_token = token.access_token
         self._refresh_token = token.refresh_token
         self._expires_at = datetime.now(timezone.utc) + timedelta(seconds=token.expires_in - 30)
@@ -144,6 +177,11 @@ class VeeamClient:
         if self._expires_at and datetime.now(timezone.utc) < self._expires_at:
             return
 
+        if not self._refresh_token:
+            # Nothing to refresh with — first use, or a session invalidated below
+            await self.connect()
+            return
+
         login_mod = importlib.import_module(f"{self.package}.api.login.create_token")
         create_token = getattr(login_mod, "asyncio")
 
@@ -156,10 +194,13 @@ class VeeamClient:
             "ELoginGrantType",
         )
 
-        Client = getattr(importlib.import_module(f"{self.package}.client"), "Client")
         AuthenticatedClient = getattr(importlib.import_module(f"{self.package}.client"), "AuthenticatedClient")
 
-        # try refresh first
+        # Try the refresh grant first, then fall back to the password grant. A refresh
+        # token expires or is revoked server-side, and the server reports that by
+        # *returning* an Error rather than raising — so a non-token result has to fall
+        # back just like an exception does, or every later call uses a stale token.
+        token = None
         try:
             body = TokenLoginSpec(
                 grant_type=ELoginGrantType.REFRESH_TOKEN,
@@ -171,24 +212,20 @@ class VeeamClient:
                 x_api_version=self.api_version,
             )
         except Exception:
-            # fallback to password
-            tmp = Client(
-                base_url=self.host,
-                verify_ssl=self.verify_ssl,
-                headers={"x-api-version": self.api_version},
-            )
-            body = TokenLoginSpec(
-                grant_type=ELoginGrantType.PASSWORD,
-                username=self.username,
-                password=self.password,
-            )
-            token = await create_token(
-                client=tmp,
-                body=body,
-                x_api_version=self.api_version,
-            )
+            token = None
+
+        if not _is_token(token):
+            self._invalidate_session()
+            await self.connect()
+            return
 
         self._store_token(token, AuthenticatedClient)
+
+    def _invalidate_session(self):
+        """Forget the current token so the next call authenticates from scratch."""
+        self._access_token = None
+        self._refresh_token = None
+        self._expires_at = None
 
     # ----------------------------
     # API access
@@ -222,4 +259,19 @@ class VeeamClient:
         if "x_api_version" not in kwargs:
             kwargs["x_api_version"] = self.api_version
 
-        return await fn(client=self._client, *args, **kwargs)
+        try:
+            return await fn(client=self._client, *args, **kwargs)
+        except JSONDecodeError as err:
+            # VBR answers a rejected token with an empty body, which the generated parser
+            # reports as "Expecting value: line 1 column 1 (char 0)" — the same error from
+            # every endpoint until the process restarts. Drop the session so the next call
+            # authenticates again.
+            #
+            # The call is deliberately not retried here: the operation may not be
+            # idempotent (starting a job, for instance), and a body that failed to decode
+            # is no proof the server did not act on it.
+            self._invalidate_session()
+            raise PermissionError(
+                "Veeam returned an undecodable response, which usually means the session "
+                f"was rejected; re-authenticating on the next call ({err})"
+            ) from err


### PR DESCRIPTION
create_token returns an Error model for a documented failure such as 401, and None for an undocumented status — it does not raise. _store_token assumed a token and read .access_token straight off the result, so a revoked or expired refresh token surfaced as:

    'Error' object has no attribute 'access_token'

and the fallback to the password grant never ran, because it was reached only from an except branch. Every later call then used a dead token, and since VBR answers a rejected token with an empty body, the generated parser reported "Expecting value: line 1 column 1 (char 0)" from every endpoint until the process restarted. Reported downstream as Cenvora/ha-veeam-br#82 and #83.

- Validate create_token results. A non-token now raises PermissionError naming the server's own message, which a caller can tell apart from an unreachable server and use to prompt for re-authentication.
- Fall back to the password grant when the refresh grant is *refused*, not only when it raises, and drop the stale session first.
- Connect from scratch when there is no refresh token, rather than sending a refresh request with None.
- In call(), treat an undecodable response as a rejected session: drop the token so the next call re-authenticates, and raise PermissionError explaining it. The operation is deliberately not retried — it may not be idempotent, and a body that failed to decode is no proof the server did not act.

Verified against a mock VBR: a refused refresh now falls back to one password login and the call succeeds; a dead session raises PermissionError and clears itself.