### PR TITLE
Add API version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,45 @@ async def main():
 asyncio.run(main())
 ```
 
+#### Detect the API version a server serves
+
+The REST API has no endpoint that reports its supported versions, and Veeam's guidance is
+that the caller picks one. What a server does expose is a Swagger document per version it
+serves, so `detect_api_version` probes those and returns the newest version that both the
+server serves and this library can speak:
+
+```python
+import asyncio
+from veeam_br.client import VeeamClient
+from veeam_br.discovery import detect_api_version
+
+async def main():
+    base_url = "https://vbr.example.com:9419"
+
+    api_version = await detect_api_version(base_url, verify_ssl=False)
+    if api_version is None:
+        # Swagger may be unreachable, disabled or gated — choose your own default
+        api_version = "1.3-rev1"
+
+    vc = VeeamClient(
+        host=base_url,
+        username="administrator",
+        password="SuperSecretPassword",
+        api_version=api_version,
+        verify_ssl=False,
+    )
+    await vc.connect()
+
+asyncio.run(main())
+```
+
+Detection needs no credentials, so it can run before you have any. Probes are concurrent, so
+it costs roughly one round trip regardless of how many versions this library supports.
+
+Resolve it once and store the result rather than detecting on every start: a server upgrade
+would otherwise silently move you onto a newer revision, and revisions rename enum values and
+add required fields.
+
 #### Call an API endpoint (async)
 ```python
 repos = await vc.call(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,190 @@
+"""Tests for API version detection.
+
+Served against httpx.MockTransport, so the probing behaviour is exercised for real rather
+than mocked out.
+"""
+
+import httpx
+import pytest
+
+from veeam_br.discovery import (
+    detect_api_version,
+    newest_first,
+    swagger_url,
+)
+from veeam_br.versions import VERSION_TO_PACKAGE
+
+BASE_URL = "https://vbr.example.com:9419"
+
+
+def make_client(served, status_for_unserved=404, fail_with=None):
+    """An httpx client whose server serves Swagger only for `served` versions."""
+    requested = []
+
+    def handler(request):
+        requested.append(str(request.url))
+        if fail_with is not None:
+            raise fail_with
+        for version in served:
+            if request.url.path == f"/swagger/v{version}/swagger.json":
+                # Real documents are several MB; the body should never be needed
+                return httpx.Response(200, json={"openapi": "3.0.1"})
+        return httpx.Response(status_for_unserved)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler)), requested
+
+
+def test_swagger_url_adds_the_v_prefix():
+    """Swagger paths carry a "v" that the x-api-version header does not."""
+    assert (
+        swagger_url(BASE_URL, "1.3-rev2")
+        == f"{BASE_URL}/swagger/v1.3-rev2/swagger.json"
+    )
+
+
+def test_swagger_url_tolerates_a_trailing_slash():
+    assert swagger_url(BASE_URL + "/", "1.2-rev1").count("//") == 1
+
+
+@pytest.mark.parametrize(
+    "versions,expected",
+    [
+        (["1.2-rev1", "1.3-rev2", "1.3-rev0"], ["1.3-rev2", "1.3-rev0", "1.2-rev1"]),
+        # Numeric ordering, which string sorting would get wrong
+        (["1.3-rev2", "1.3-rev10"], ["1.3-rev10", "1.3-rev2"]),
+        (["1.3-rev0", "1.10-rev0"], ["1.10-rev0", "1.3-rev0"]),
+        # Unrecognizable entries are dropped rather than ordered arbitrarily
+        (["1.3-rev1", "nonsense", None, ""], ["1.3-rev1"]),
+        ([], []),
+    ],
+)
+def test_newest_first(versions, expected):
+    assert newest_first(versions) == expected
+
+
+@pytest.mark.asyncio
+async def test_detects_the_newest_version_the_server_serves():
+    client, _ = make_client(served=["1.2-rev1", "1.3-rev0"])
+
+    detected = await detect_api_version(BASE_URL, client=client)
+
+    assert detected == "1.3-rev0", "an older server must not be handed a newer revision"
+
+
+@pytest.mark.asyncio
+async def test_detects_the_newest_when_the_server_serves_everything():
+    client, _ = make_client(served=list(VERSION_TO_PACKAGE))
+
+    detected = await detect_api_version(BASE_URL, client=client)
+
+    assert detected == newest_first(VERSION_TO_PACKAGE)[0]
+
+
+@pytest.mark.asyncio
+async def test_probes_only_versions_this_package_supports():
+    """Reporting a version the SDK cannot speak would be useless to the caller."""
+    client, requested = make_client(served=list(VERSION_TO_PACKAGE))
+
+    await detect_api_version(BASE_URL, client=client)
+
+    probed = {
+        url.split("/swagger/v")[1].removesuffix("/swagger.json") for url in requested
+    }
+    assert probed == set(VERSION_TO_PACKAGE)
+
+
+@pytest.mark.asyncio
+async def test_candidate_list_can_be_narrowed():
+    client, requested = make_client(served=["1.3-rev1"])
+
+    detected = await detect_api_version(BASE_URL, client=client, versions=["1.3-rev1"])
+
+    assert detected == "1.3-rev1"
+    assert len(requested) == 1
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_version_answers():
+    """The caller then falls back to a version of its own choosing."""
+    client, _ = make_client(served=[])
+
+    assert await detect_api_version(BASE_URL, client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_swagger_is_gated():
+    """Some deployments may require auth for the docs, or disable them."""
+    client, _ = make_client(served=[], status_for_unserved=401)
+
+    assert await detect_api_version(BASE_URL, client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_server_is_unreachable():
+    client, _ = make_client(served=[], fail_with=httpx.ConnectError("unreachable"))
+
+    assert await detect_api_version(BASE_URL, client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_a_probe_times_out():
+    client, _ = make_client(served=[], fail_with=httpx.ReadTimeout("too slow"))
+
+    assert await detect_api_version(BASE_URL, client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_a_single_failing_probe_does_not_hide_the_others():
+    """One version timing out must not lose a version that did answer."""
+    calls = {"n": 0}
+
+    def handler(request):
+        if request.url.path == "/swagger/v1.3-rev2/swagger.json":
+            raise httpx.ReadTimeout("too slow")
+        if request.url.path == "/swagger/v1.3-rev1/swagger.json":
+            calls["n"] += 1
+            return httpx.Response(200, json={"openapi": "3.0.1"})
+        return httpx.Response(404)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    detected = await detect_api_version(BASE_URL, client=client)
+
+    assert detected == "1.3-rev1"
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_candidate_list_makes_no_requests():
+    client, requested = make_client(served=[])
+
+    assert await detect_api_version(BASE_URL, client=client, versions=[]) is None
+    assert requested == []
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_client_is_left_open():
+    """Reusing a caller's client must not close it out from under them."""
+    client, _ = make_client(served=["1.3-rev1"])
+
+    await detect_api_version(BASE_URL, client=client)
+
+    assert not client.is_closed
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_detected_version_is_usable_with_veeam_client():
+    """Detection is only useful if its result routes to a real SDK package."""
+    from veeam_br.client import VeeamClient
+
+    client, _ = make_client(served=list(VERSION_TO_PACKAGE))
+    detected = await detect_api_version(BASE_URL, client=client)
+
+    vc = VeeamClient(
+        host=BASE_URL,
+        username="administrator",
+        password="pw",
+        api_version=detected,
+    )
+    assert vc.package == VERSION_TO_PACKAGE[detected]

--- a/veeam_br/discovery.py
+++ b/veeam_br/discovery.py
@@ -1,0 +1,129 @@
+"""Detect which REST API version a Veeam Backup & Replication server offers.
+
+The REST API has no endpoint that reports its own supported versions — every request must
+carry an ``x-api-version`` header, and Veeam's guidance is that the caller chooses:
+
+    "you should be picking the API version you plan to use for your production code, the
+    API cannot (and will not) decide for you"
+
+What a server does expose is one Swagger document per version it serves, so probing
+``/swagger/v{version}/swagger.json`` reveals the set. VeeamHub's config collector uses the
+same approach:
+https://github.com/VeeamHub/veeam-config-collector/blob/master/Veeam_Config_Collector.ps1
+
+``detect_api_version`` intersects that with the versions this package can actually speak
+(``VERSION_TO_PACKAGE``) and returns the newest one, so the answer is always a version the
+caller can pass straight to ``VeeamClient``.
+
+Detection is best-effort: Swagger endpoints may be unreachable, disabled, or gated, and any
+of those cases returns None so the caller can fall back to a version of its own choosing
+rather than failing outright.
+"""
+
+import asyncio
+import logging
+from collections.abc import Iterable, Sequence
+
+import httpx
+
+from .versions import VERSION_TO_PACKAGE
+
+_LOGGER = logging.getLogger(__name__)
+
+# Probes run concurrently, so this bounds the whole detection rather than each version
+DEFAULT_TIMEOUT = 8.0
+
+# Swagger paths carry a "v" prefix that the x-api-version header does not: version
+# "1.3-rev2" is documented at /swagger/v1.3-rev2/swagger.json
+SWAGGER_PATH = "/swagger/v{version}/swagger.json"
+
+
+def swagger_url(base_url: str, version: str) -> str:
+    """Build the Swagger document URL for one API version."""
+    return f"{base_url.rstrip('/')}{SWAGGER_PATH.format(version=version)}"
+
+
+def newest_first(versions: Iterable[str]) -> list[str]:
+    """Order API versions newest first, dropping any that are not recognizable.
+
+    Versions look like "1.3-rev2". Comparing the numbers rather than the strings keeps a
+    hypothetical "1.10-rev0" above "1.3-rev0" instead of below it.
+    """
+
+    def key(version):
+        try:
+            head, _, revision = version.partition("-rev")
+            major, _, minor = head.partition(".")
+            return (int(major), int(minor), int(revision))
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    # Filter before sorting: an unrecognizable entry has no key to compare, and mixing
+    # those into the sort raises rather than just ordering them last
+    ranked = [(key(version), version) for version in versions]
+    return [version for _, version in sorted((r for r in ranked if r[0]), reverse=True)]
+
+
+async def _serves(client, base_url: str, version: str, timeout: float):
+    """Return the version if the server serves its Swagger document, else None."""
+    url = swagger_url(base_url, version)
+    try:
+        # Streamed so only the status line is needed; these documents are several MB
+        async with client.stream("GET", url, timeout=timeout) as response:
+            if response.status_code == 200:
+                return version
+            _LOGGER.debug("%s returned HTTP %s", url, response.status_code)
+            return None
+    except Exception as err:
+        _LOGGER.debug("%s did not answer: %s", url, err)
+        return None
+
+
+async def detect_api_version(
+    base_url: str,
+    *,
+    verify_ssl: bool = True,
+    timeout: float = DEFAULT_TIMEOUT,
+    versions: Sequence[str] | None = None,
+    client: "httpx.AsyncClient | None" = None,
+) -> str | None:
+    """Return the newest API version this server serves and this package supports.
+
+    Args:
+        base_url: Server base URL, e.g. "https://vbr.example.com:9419".
+        verify_ssl: Whether to verify the server certificate. Ignored when ``client`` is
+            given, since the caller's client carries its own settings.
+        timeout: Per-request timeout in seconds. Probes are concurrent.
+        versions: Candidate versions. Defaults to everything this package can speak.
+        client: An existing httpx.AsyncClient to reuse instead of opening one.
+
+    Returns:
+        A version string such as "1.3-rev2", or None if no Swagger document answered — the
+        caller should then fall back to a version it chooses.
+    """
+    candidates = newest_first(VERSION_TO_PACKAGE if versions is None else versions)
+    if not candidates:
+        return None
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(verify=verify_ssl)
+
+    try:
+        results = await asyncio.gather(
+            *(_serves(client, base_url, version, timeout) for version in candidates),
+            return_exceptions=True,
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    served = {result for result in results if isinstance(result, str)}
+    if not served:
+        _LOGGER.debug("No Swagger document answered on %s", base_url)
+        return None
+
+    # candidates is newest-first, so the first match is the newest version served
+    detected = next(version for version in candidates if version in served)
+    _LOGGER.debug("%s serves %s; selected %s", base_url, sorted(served), detected)
+    return detected


### PR DESCRIPTION
The REST API has no endpoint reporting its supported versions — every request carries x-api-version, and Veeam's position is that the caller chooses. What a server does expose is one Swagger document per version it serves, so detect_api_version() probes /swagger/v{version}/swagger.json and returns the newest version the server serves *and* this package can speak, which is the only answer useful to a caller. VeeamHub's config collector discovers the version the same way.

This belongs here rather than in each consumer: the candidate list is VERSION_TO_PACKAGE, so it cannot drift from what the package ships, and the Swagger path convention — including the "v" prefix that x-api-version does not carry — is Veeam API knowledge, not application knowledge.

Best-effort by contract. Swagger endpoints can be unreachable, disabled or gated, and all of those return None so a caller falls back to a version of its own choosing instead of failing. Probes run concurrently, so detection costs about one round trip, and needs no credentials — it can run before any are available.

Documents that callers should resolve once and store the result: re-detecting on every start would silently move an existing deployment onto a newer revision, and revisions rename enum values and add required fields.