### PR TITLE
Detect which port the REST API answers on

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ asyncio.run(main())
 Detection needs no credentials, so it can run before you have any. Probes are concurrent, so
 it costs roughly one round trip regardless of how many versions this library supports.
 
+If you do not know the port either, `detect_rest_api` finds both at once. Veeam B&R 13.1
+serves the REST API on 443 and no longer needs a dedicated port; 9419 still answers on 13.1
+and is the only port on older releases, but Veeam has said it will be removed in a future
+release:
+
+```python
+from veeam_br.discovery import detect_rest_api
+
+endpoint = await detect_rest_api("vbr.example.com", verify_ssl=False)
+if endpoint:
+    print(endpoint.port, endpoint.api_version)  # e.g. 443 1.3-rev2
+    base_url = f"https://vbr.example.com{endpoint.base_url_suffix}"
+```
+
+Ports are tried in preference order — 443 before 9419 by default, since a 13.1 server answers
+on both — and the newest version served by the winning port is returned.
+
 Resolve it once and store the result rather than detecting on every start: a server upgrade
 would otherwise silently move you onto a newer revision, and revisions rename enum values and
 add required fields.

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,7 +8,9 @@ import httpx
 import pytest
 
 from veeam_br.discovery import (
+    RestApiEndpoint,
     detect_api_version,
+    detect_rest_api,
     newest_first,
     swagger_url,
 )
@@ -188,3 +190,140 @@ async def test_detected_version_is_usable_with_veeam_client():
         api_version=detected,
     )
     assert vc.package == VERSION_TO_PACKAGE[detected]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint detection: which port, and which version on it
+#
+# 13.1 serves the REST API on 443 and answers on 9419 too; older releases only have 9419,
+# and Veeam has said 9419 will be removed in a future release.
+# ---------------------------------------------------------------------------
+
+
+def make_endpoint_client(served, fail_with=None):
+    """A client whose server serves Swagger only at the given (port, version) pairs.
+
+    httpx reports url.port as None for a scheme's default port, so an https URL written as
+    ":443" arrives here with no port at all — hence the fallback. A real server still sees
+    the TCP port it was reached on.
+    """
+    requested = []
+
+    def port_of(request):
+        return request.url.port or 443
+
+    def handler(request):
+        requested.append((port_of(request), str(request.url.path)))
+        if fail_with is not None:
+            raise fail_with
+        for port, version in served:
+            if (
+                port_of(request) == port
+                and request.url.path == f"/swagger/v{version}/swagger.json"
+            ):
+                return httpx.Response(200, json={"openapi": "3.0.1"})
+        return httpx.Response(404)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler)), requested
+
+
+@pytest.mark.asyncio
+async def test_prefers_443_when_a_server_answers_on_both():
+    """A 13.1 server serves both; the modern port is the one to keep using."""
+    client, _ = make_endpoint_client([(443, "1.3-rev2"), (9419, "1.3-rev2")])
+
+    endpoint = await detect_rest_api("vbr.example.com", client=client)
+
+    assert endpoint == RestApiEndpoint(port=443, api_version="1.3-rev2")
+
+
+@pytest.mark.asyncio
+async def test_finds_the_legacy_port_on_an_older_server():
+    """Pre-13.1 servers have nothing on 443."""
+    client, _ = make_endpoint_client([(9419, "1.3-rev0")])
+
+    endpoint = await detect_rest_api("vbr.example.com", client=client)
+
+    assert endpoint == RestApiEndpoint(port=9419, api_version="1.3-rev0")
+
+
+@pytest.mark.asyncio
+async def test_reports_the_newest_version_on_the_preferred_port():
+    """Port preference comes first, then the newest version that port serves."""
+    client, _ = make_endpoint_client(
+        [(443, "1.3-rev1"), (443, "1.3-rev2"), (9419, "1.3-rev2")]
+    )
+
+    endpoint = await detect_rest_api("vbr.example.com", client=client)
+
+    assert endpoint == RestApiEndpoint(port=443, api_version="1.3-rev2")
+
+
+@pytest.mark.asyncio
+async def test_port_order_is_the_callers_choice():
+    """A caller that wants the legacy port checked first can say so."""
+    client, _ = make_endpoint_client([(443, "1.3-rev2"), (9419, "1.3-rev2")])
+
+    endpoint = await detect_rest_api(
+        "vbr.example.com", ports=(9419, 443), client=client
+    )
+
+    assert endpoint.port == 9419
+
+
+@pytest.mark.asyncio
+async def test_probes_every_port_and_version_combination():
+    client, requested = make_endpoint_client([])
+
+    await detect_rest_api(
+        "vbr.example.com", client=client, versions=["1.3-rev2", "1.2-rev1"]
+    )
+
+    assert sorted(requested) == sorted(
+        [
+            (port, f"/swagger/v{version}/swagger.json")
+            for port in (443, 9419)
+            for version in ("1.3-rev2", "1.2-rev1")
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_port_answers():
+    """Caller keeps whatever the user configured rather than guessing."""
+    client, _ = make_endpoint_client([])
+
+    assert await detect_rest_api("vbr.example.com", client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_the_host_is_unreachable():
+    client, _ = make_endpoint_client([], fail_with=httpx.ConnectError("no route"))
+
+    assert await detect_rest_api("vbr.example.com", client=client) is None
+
+
+@pytest.mark.asyncio
+async def test_no_ports_means_no_requests():
+    client, requested = make_endpoint_client([])
+
+    assert await detect_rest_api("vbr.example.com", ports=(), client=client) is None
+    assert requested == []
+
+
+@pytest.mark.asyncio
+async def test_detected_endpoint_builds_a_working_base_url():
+    """The result should drop straight into a VeeamClient host argument."""
+    from veeam_br.client import VeeamClient
+
+    client, _ = make_endpoint_client([(443, "1.3-rev2")])
+    endpoint = await detect_rest_api("vbr.example.com", client=client)
+
+    vc = VeeamClient(
+        host=f"https://vbr.example.com{endpoint.base_url_suffix}",
+        username="administrator",
+        password="pw",
+        api_version=endpoint.api_version,
+    )
+    assert vc.host == "https://vbr.example.com:443"
+    assert vc.package == VERSION_TO_PACKAGE[endpoint.api_version]

--- a/veeam_br/discovery.py
+++ b/veeam_br/discovery.py
@@ -23,6 +23,7 @@ rather than failing outright.
 import asyncio
 import logging
 from collections.abc import Iterable, Sequence
+from typing import NamedTuple
 
 import httpx
 
@@ -36,6 +37,25 @@ DEFAULT_TIMEOUT = 8.0
 # Swagger paths carry a "v" prefix that the x-api-version header does not: version
 # "1.3-rev2" is documented at /swagger/v1.3-rev2/swagger.json
 SWAGGER_PATH = "/swagger/v{version}/swagger.json"
+
+# Ports the REST API is reachable on, most current first. 13.1 serves it on 443 and answers
+# on 9419 too for backward compatibility; 9419 is the only port on older releases and Veeam
+# has said it will be removed in a future release.
+REST_PORT = 443
+LEGACY_REST_PORT = 9419
+DEFAULT_PORTS = (REST_PORT, LEGACY_REST_PORT)
+
+
+class RestApiEndpoint(NamedTuple):
+    """Where a server's REST API answers."""
+
+    port: int
+    api_version: str
+
+    @property
+    def base_url_suffix(self) -> str:
+        """Port suffix for building a base URL, e.g. ":443"."""
+        return f":{self.port}"
 
 
 def swagger_url(base_url: str, version: str) -> str:
@@ -127,3 +147,70 @@ async def detect_api_version(
     detected = next(version for version in candidates if version in served)
     _LOGGER.debug("%s serves %s; selected %s", base_url, sorted(served), detected)
     return detected
+
+
+async def detect_rest_api(
+    host: str,
+    *,
+    ports: Sequence[int] = DEFAULT_PORTS,
+    versions: Sequence[str] | None = None,
+    verify_ssl: bool = True,
+    timeout: float = DEFAULT_TIMEOUT,
+    client: "httpx.AsyncClient | None" = None,
+) -> RestApiEndpoint | None:
+    """Find where a server answers: which port, and which API version.
+
+    Veeam Backup & Replication 13.1 serves the REST API on 443 and no longer needs a
+    dedicated port. 9419 still answers on 13.1 for backward compatibility, and is the only
+    port on older releases, but Veeam has said it will be removed in a future release. A
+    caller therefore cannot assume either port, and the Swagger URL contains the port — so
+    one probe sweep answers both questions at once.
+
+    Args:
+        host: Hostname or address, without scheme or port.
+        ports: Candidate ports, in order of preference. 13.1 answers on both, so the first
+            that responds wins rather than the highest-numbered.
+        versions: Candidate versions. Defaults to everything this package can speak.
+        verify_ssl: Whether to verify the server certificate. Ignored when ``client`` is
+            given, since the caller's client carries its own settings.
+        timeout: Per-request timeout in seconds. Probes are concurrent.
+        client: An existing httpx.AsyncClient to reuse instead of opening one.
+
+    Returns:
+        A RestApiEndpoint(port, api_version), or None if nothing answered.
+    """
+    candidates = newest_first(VERSION_TO_PACKAGE if versions is None else versions)
+    if not candidates or not ports:
+        return None
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient(verify=verify_ssl)
+
+    attempts = [(port, version) for port in ports for version in candidates]
+
+    try:
+        results = await asyncio.gather(
+            *(_serves(client, f"https://{host}:{port}", version, timeout) for port, version in attempts),
+            return_exceptions=True,
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    answered = {(port, version) for (port, version), result in zip(attempts, results) if isinstance(result, str)}
+    if not answered:
+        _LOGGER.debug("Nothing answered on %s across ports %s", host, list(ports))
+        return None
+
+    # ports is preference-ordered and candidates is newest-first, so the first hit in that
+    # nesting is the preferred port running its newest served version
+    port, version = next(attempt for attempt in attempts if attempt in answered)
+    _LOGGER.debug(
+        "%s answered on %s; selected port %s with %s",
+        host,
+        sorted(answered),
+        port,
+        version,
+    )
+    return RestApiEndpoint(port=port, api_version=version)


### PR DESCRIPTION
Veeam B&R 13.1 serves the REST API on 443 and no longer needs a dedicated port. 9419 still answers on 13.1 for backward compatibility and is the only port on older releases, but Veeam has said it will be removed in a future release — so a caller can no longer assume either port.

detect_rest_api(host) sweeps port x version and returns a RestApiEndpoint(port, api_version). The Swagger URL contains the port, so one probe sweep answers both questions at once rather than detecting a port and then re-probing for a version.

Ports are tried in preference order, 443 before 9419, because a 13.1 server answers on both and the modern port is the one worth settling on; the newest version served by the winning port wins. Callers that want the legacy port checked first can pass their own order.

Same best-effort contract as detect_api_version: nothing answering returns None, so a caller keeps whatever the user configured instead of guessing.